### PR TITLE
Fix - showing the correct current versions

### DIFF
--- a/AboutBox.js
+++ b/AboutBox.js
@@ -115,8 +115,8 @@ const AboutBox = ({ textToc, currVersions, textTitle, sheet, openUri }) => {
       </View>
     );
   }
-  const showSourceVersionDetails = textLanguage != 'english';
-  const showTranslationVersionDetails = textLanguage != 'hebrew';
+  const showSourceVersionDetails = textLanguage !== 'english';
+  const showTranslationVersionDetails = textLanguage !== 'hebrew';
   const versionSectionHe =
     (!!vh && showSourceVersionDetails ? <View style={styles.currVersionSection}>
       <View style={[styles.aboutHeaderWrapper, theme.bordered]}>

--- a/AboutBox.js
+++ b/AboutBox.js
@@ -115,8 +115,10 @@ const AboutBox = ({ textToc, currVersions, textTitle, sheet, openUri }) => {
       </View>
     );
   }
+  const showSourceVersionDetails = textLanguage != 'english';
+  const showTranslationVersionDetails = textLanguage != 'hebrew';
   const versionSectionHe =
-    (!!vh && !vh.disabled ? <View style={styles.currVersionSection}>
+    (!!vh && showSourceVersionDetails ? <View style={styles.currVersionSection}>
       <View style={[styles.aboutHeaderWrapper, theme.bordered]}>
         <Text style={[styles.aboutHeader, theme.secondaryText, hei ? styles.heInt : null]}>{ strings.currentHebrewVersion }</Text>
       </View>
@@ -126,7 +128,7 @@ const AboutBox = ({ textToc, currVersions, textTitle, sheet, openUri }) => {
       />
     </View> : null );
   const versionSectionEn =
-    (!!ve && !ve.disabled ? <View style={styles.currVersionSection}>
+    (!!ve && showTranslationVersionDetails ? <View style={styles.currVersionSection}>
       <View style={[styles.aboutHeaderWrapper, theme.bordered]}>
         <Text style={[styles.aboutHeader, theme.secondaryText, hei ? styles.heInt : null]}>{ strings.currentEnglishVersion }</Text>
       </View>


### PR DESCRIPTION
There was some weirdness with the wrapping Promise in `ReaderApp.setCurrVersions()` causing (I think) the `disabled` property on each currVersion not to be set in time to coincide with the textLanguage changing. So the text language changed but the current versions were mislabeled until a second press on the same toggle value allowed the change through. 
This PR just circumnavigates that by checking the text language directly fro which "current versions" should appear in the about box.  