### PR TITLE
fix(topics): dont crash if parashaData doesn't exist

### DIFF
--- a/TopicPage.js
+++ b/TopicPage.js
@@ -683,7 +683,8 @@ const TopicSideColumn = ({ topic, links, openTopic, openRef, parashaData, tref }
     />
   );
 
-  const hasReadings = parashaData && (!Array.isArray(parashaData) || parashaData.length > 0) && tref;
+  // parashaData can be an empty array if it is missing
+  const hasReadings = parashaData && !Array.isArray(parashaData)  && tref;
   const readingsComponent = hasReadings ? (
     <ReadingsComponent parashaData={parashaData} tref={tref} openRef={openRef} />
   ) : null;

--- a/TopicPage.js
+++ b/TopicPage.js
@@ -682,7 +682,9 @@ const TopicSideColumn = ({ topic, links, openTopic, openRef, parashaData, tref }
       isCategory={l.isCategory}
     />
   );
-  const readingsComponent = (parashaData && tref) ? (
+
+  const hasReadings = parashaData && (!Array.isArray(parashaData) || parashaData.length > 0) && tref;
+  const readingsComponent = hasReadings ? (
     <ReadingsComponent parashaData={parashaData} tref={tref} openRef={openRef} />
   ) : null;
   const linksComponent = (


### PR DESCRIPTION
We don't currently have a parsha calendar entry for Vzot Habracha because it's not read on Shabbat. This may change but is a Product decision. parashaData is not necessarily falsey when calendar data doesn't exist so we need to check all the cases.