### PR TITLE
Fix cache versions by section

### DIFF
--- a/api.js
+++ b/api.js
@@ -351,7 +351,6 @@ var Api = {
           Sefaria.cacheVersionsAvailableBySection(ref,
               response.map(v => ({versionTitle: v.versionTitle, language: v.language}))
           );
-          Sefaria.cacheVersionObjectByTitle(response, Sefaria.textTitleForRef(ref));
           Sefaria.api._versions[ref] = response;
           resolve(response);
         })

--- a/sefaria.js
+++ b/sefaria.js
@@ -424,7 +424,7 @@ Sefaria = {
   getCurrVersionObjectBySection: function(ref, lang) {
     const currVTitle = Sefaria._currVersionsBySection[ref]?.[lang];
     const title = Sefaria.textTitleForRef(ref);
-    const versionObjects = Sefaria._versionObjectsByTitle[title] || [];
+    const versionObjects = Sefaria._versionObjectsByTitle[title] || {};
     return versionObjects[Sefaria.getVersionObjectCacheKey(currVTitle, lang)];
   },
   getVersionObject: function(vtitle, lang, title) {

--- a/sefaria.js
+++ b/sefaria.js
@@ -393,12 +393,14 @@ Sefaria = {
     for (let lang of ['en', 'he']) {
       const versionObject = {};
       attrs.forEach(attr => {
+        // remove 'he' prefix from attributes
         const dataAttr = lang === 'he' ? `he${attr.at(0).toUpperCase()}${attr.substring(1)}` : attr;
         versionObject[attr] = data[dataAttr];
       });
+      versionObject.language = lang;
       versionObjects.push(versionObject);
     }
-    Sefaria.cacheVersionObjectByTitle(versionObjects, data.title);
+    Sefaria.cacheVersionObjectByTitle(versionObjects, data.indexTitle);
   },
   cacheVersionObjectByTitle: function(versionObjects, title) {
     /**


### PR DESCRIPTION
Fixes issues with caching version information for both offline and online mode. Each mode had its own bugs. Online mode had multiple bugs actually (!).

Bugs in offline mode:
- We only cached version info is fallbackOnDefaultVersions was true. We should always cache it. However, we need to be a little more careful because the version title might have fallen back on a default version.

Bugs in online mode:
- dont cache version info from version api as there's no need
- use indexTitle instead of non-existant title
- add 'language' attribute to version objects which is needed to build cache key