### PR TITLE
Gracefully fail if one version errors

### DIFF
--- a/offline.js
+++ b/offline.js
@@ -224,7 +224,13 @@ const loadOfflineSectionByVersions = async function(selectedVersions, allVersion
     }
     const loadedVersions = {};  // actual versions that were loaded, taking into account falling back on default version
     for (let [lang, vtitle] of Object.entries(selectedVersions)) {
-        const [versionText, loadedVTitle] = await loadOfflineSectionByVersionWithCacheAndFallback(fileNameStem, lang, vtitle, defaultVersions[lang]);
+        let versionText, loadedVTitle;
+        try {
+            [versionText, loadedVTitle] = await loadOfflineSectionByVersionWithCacheAndFallback(fileNameStem, lang, vtitle, defaultVersions[lang]);
+        } catch (error) {
+            if (fallbackOnDefaultVersions) { continue; }  // fail gracefully and return whatever data exists
+            throw error;
+        }
         loadedVersions[lang] = loadedVTitle;
         // versionText may be depth-3. extract depth-2 if necessary.
         textByLang[lang] = getSectionFromJsonData(ref, versionText);

--- a/offline.js
+++ b/offline.js
@@ -223,17 +223,22 @@ const loadOfflineSectionByVersions = async function(selectedVersions, allVersion
         defaultVersions = populateMissingVersions({}, allVersions);
     }
     const loadedVersions = {};  // actual versions that were loaded, taking into account falling back on default version
+    let versionLoadError;
     for (let [lang, vtitle] of Object.entries(selectedVersions)) {
         let versionText, loadedVTitle;
         try {
             [versionText, loadedVTitle] = await loadOfflineSectionByVersionWithCacheAndFallback(fileNameStem, lang, vtitle, defaultVersions[lang]);
         } catch (error) {
-            if (fallbackOnDefaultVersions) { continue; }  // fail gracefully and return whatever data exists
-            throw error;
+            versionLoadError = error;
         }
         loadedVersions[lang] = loadedVTitle;
         // versionText may be depth-3. extract depth-2 if necessary.
         textByLang[lang] = getSectionFromJsonData(ref, versionText);
+    }
+    if (Object.keys(textByLang).length === 0 && versionLoadError) {
+        // if no versions were loaded successfully, throw.
+        // else, assume some content is better than none.
+        throw versionLoadError;
     }
     Sefaria.cacheCurrVersionsBySection(loadedVersions, ref);
     return textByLang;


### PR DESCRIPTION
Previously, if one version didn't exist offline, we'd switch to online. Due to a bug in the export script, many books contained erroneous version information and cause at least one version to fail to load on the app. 

Made a product decision that some offline content is better than switching to online (because you may in fact be offline). This solves the issue because the users aren't forced into online mode when they try to load a non-existing version.