### PR TITLE
fix(TextColumn): show last segments when connections panel is open.

### DIFF
--- a/TextColumn.js
+++ b/TextColumn.js
@@ -787,10 +787,12 @@ class TextColumn extends React.PureComponent {
   };
 
   render() {
+    const paddingBottom = Dimensions.get('window').height * 0.7;  //0.7 allows oneline last book segment to show in the top when it's pressed, but not to scroll it out of screen
     return (
         <View style={styles.textColumn}>
           <ErrorBoundary FallbackComponent={ErrorBoundaryFallbackComponent} onError={this._textErrorBoundaryAlert}>
             <SectionList
+              contentContainerStyle={{ paddingBottom: paddingBottom }}
               style={styles.scrollViewPaddingInOrderToScroll}
               ref={this._getSectionListRef}
               sections={this.state.dataSource}


### PR DESCRIPTION
Bugfix

The problem:
When connections panel is open, one cannot navigate to the last segment(s) (inless it's long enough). Also, when pressing it, the connections panel will open but on a previous segment.

The solution:
Adding bottom padding to TextColumn.

Undesired side effect:
Now, when the connections panel is open, one can scroll all the text out of the screen.

Todo - a better solution:
Adding an empty <View> in renderListFooter enables scrolling to the last segment. Still, on pressing the last segment it wil remain 'under' the connections panel. This is because the scrollToLocation happens before the panel is opened. A better wolution will find how to scrollToLocation after opening the panel.