### PR TITLE
fix(links): only use collective title if category is commentary.

### DIFF
--- a/api.js
+++ b/api.js
@@ -512,12 +512,8 @@ var Api = {
 
   related: async function(ref) {
     //await Sefaria.api._abortRequestType('related');  doesn't seem necessary and causes many failed related calls when sections are small
-    const cached = Sefaria.api._related[ref];
-    if (!!cached) { return cached; }
     try {
-      const response = await Sefaria.api._request(ref, 'related', true, {}, true);
-      Sefaria.api._related[ref] = response;
-      return response;
+      return await Sefaria.api._request(ref, 'related', true, {}, true);
     } catch(error) {
       console.log("related API error:", error, ref);
       throw error;

--- a/offline.js
+++ b/offline.js
@@ -79,6 +79,29 @@ export const loadOfflineSectionMetadataCompat = async function(ref) {
     }
 };
 
+export const loadLinksOffline = async function(ref) {
+    // mimic response of links API so that addLinksToText() will work independent of data source
+    const metadata = await loadOfflineSectionMetadataCompat(ref);
+    if (!metadata) { throw ERRORS.CANT_GET_SECTION_FROM_DATA; }
+    const linkList = (metadata.links.reduce((accum, segmentLinks, segNum) => accum.concat(
+        !!segmentLinks ? segmentLinks.map(link => {
+            const index_title = Sefaria.textTitleForRef(link.sourceRef);
+            const collectiveTitle = Sefaria.collectiveTitlesDict[index_title];
+            const category = link.category ? link.category : Sefaria.primaryCategoryForTitle(index_title);
+            return {
+                sourceRef: link.sourceRef,
+                sourceHeRef: link.sourceHeRef,
+                index_title,
+                collectiveTitle: category === "Commentary" ? collectiveTitle : undefined,
+                category,
+                anchorRef: `${ref}:${segNum+1}`,
+                sourceHasEn: link.sourceHasEn,
+            }
+        }) : []
+    ), []));
+    return {links: linkList};
+};
+
 export const openFileInSources = async function(filename) {
     const isIOS = Platform.OS === 'ios';
     let fileData;
@@ -448,6 +471,9 @@ const _JSONSourcePath = function(fileName) {
 const _zipSourcePath = function(fileName) {
     return (FileSystem.documentDirectory + "/library/" + fileName + ".zip");
 };
+
+const relatedCacheKey = (ref) => ref;
+
 
 const processFileData = function(ref, data) {
     // Annotate link objects with useful fields not included in export

--- a/offline.js
+++ b/offline.js
@@ -472,9 +472,6 @@ const _zipSourcePath = function(fileName) {
     return (FileSystem.documentDirectory + "/library/" + fileName + ".zip");
 };
 
-const relatedCacheKey = (ref) => ref;
-
-
 const processFileData = function(ref, data) {
     // Annotate link objects with useful fields not included in export
     data.content.forEach(segment => {

--- a/offlineOnline.js
+++ b/offlineOnline.js
@@ -71,12 +71,13 @@ export const loadRelated = async function(ref, online) {
             !!segmentLinks ? segmentLinks.map(link => {
                 const index_title = Sefaria.textTitleForRef(link.sourceRef);
                 const collectiveTitle = Sefaria.collectiveTitlesDict[index_title];
+                const category = link.category ? link.category : Sefaria.primaryCategoryForTitle(index_title);
                 return {
                     sourceRef: link.sourceRef,
                     sourceHeRef: link.sourceHeRef,
                     index_title,
-                    collectiveTitle,
-                    category: ("category" in link) ? link.category : Sefaria.primaryCategoryForTitle(index_title),
+                    collectiveTitle: category === "Commentary" ? collectiveTitle : undefined,
+                    category,
                     anchorRef: `${ref}:${segNum+1}`,
                     sourceHasEn: link.sourceHasEn,
                 }


### PR DESCRIPTION
In cases where the user was offline, links to quoting commentary got collective titles and became indistinguishable from regular commentary. The resource panel couldn't differentiate between both types of links leading to confusion in the UI.

To reproduce: put phone in airplane mode, go to Job 16:3. You will see Rashi in both quoting commentary and commentary. The rashi in quoting commentary should be "Rashi on I Kings".