### PR TITLE
Markdown

### DIFF
--- a/DeepLinkRouter.js
+++ b/DeepLinkRouter.js
@@ -31,7 +31,7 @@ class DeepLinkRouter extends React.PureComponent {
       ['^(sheets)/tags$', this.openMenu, ['menu']],
       ['^sheets/tags/(.+)$', this.openTopicFromTag, ['tag']],
       ['^topics/(category)/(.+)$', this.openTopic, ['categoryString','slug']],
-      ['^topics/(.+)$', {'fromOutside' : this.catchAll, 'fromInside': this.openTopic}, ['slug']],
+      ['^topics/(.+)$', {fromOutside: this.catchAll, fromInside: this.openTopic}, ['slug']],
       ['^sheets/([0-9.]+)$', this.openRefSheet, ['sheetid']],
       ['^([^/]+)$', this.openRef, ['tref']],  // NOTE: if any static page matches a title, it will try to be opened in the app. In this case, we'll need to explicitly list the route above this route.
       ['^.*$', this.catchAll],

--- a/DeepLinkRouter.js
+++ b/DeepLinkRouter.js
@@ -31,12 +31,12 @@ class DeepLinkRouter extends React.PureComponent {
       ['^(sheets)/tags$', this.openMenu, ['menu']],
       ['^sheets/tags/(.+)$', this.openTopicFromTag, ['tag']],
       ['^topics/(category)/(.+)$', this.openTopic, ['categoryString','slug']],
-      ['^topics/.+$', this.catchAll],
+      ['^topics/(.+)$', {'fromOutside' : this.catchAll, 'fromInside': this.openTopic}, ['slug']],
       ['^sheets/([0-9.]+)$', this.openRefSheet, ['sheetid']],
       ['^([^/]+)$', this.openRef, ['tref']],  // NOTE: if any static page matches a title, it will try to be opened in the app. In this case, we'll need to explicitly list the route above this route.
       ['^.*$', this.catchAll],
     ];
-    this._routes = routes.map(([ regex, func, namedCaptureGroups ]) => new Route({regex, func, namedCaptureGroups}));
+    this._routes = routes.map(([ regex, funcOrObj, namedCaptureGroups ]) => new Route({regex, funcOrObj, namedCaptureGroups}));
   }
   openMenu = ({ menu }) => {
     this.props.openMenu(menu);
@@ -108,7 +108,7 @@ class DeepLinkRouter extends React.PureComponent {
     // runs in case no route can handle this url
     this.props.openUri(url);
   };
-  route = url => {
+  route = (url, fromOutside=false) => {
     const u = new URL(url, Sefaria.api._baseHost, true);
     let { pathname, query, host, hostname } = u;
     if (!hostname.match('(?:www\.)?sefaria\.org')) {
@@ -122,16 +122,16 @@ class DeepLinkRouter extends React.PureComponent {
     // es6 dict comprehension to decode query values
     query = Object.entries(query).reduce((obj, [k, v]) => { obj[k] = decodeURIComponent(v); return obj; }, {});
     for (let r of this._routes) {
-      if (r.apply({ pathname, query, url })) { break; }
+      if (r.apply({ pathname, query, url }, fromOutside)) { break; }
     }
   };
   render() { return null; }
 }
 
 class Route {
-  constructor({ regex, func, namedCaptureGroups }) {
+  constructor({ regex, funcOrObj, namedCaptureGroups }) {
     this.regex = regex;
-    this.func = func;
+    this.funcOrObj = funcOrObj;
     this.namedCaptureGroups = namedCaptureGroups || [];
   }
   getNamedCaptureGroups = match => {
@@ -144,11 +144,16 @@ class Route {
     }
     return groups;
   };
-  apply = ({ pathname, query, url }) => {
+  apply = ({ pathname, query, url }, fromOutside) => {
     const m = pathname.match(this.regex);
     if (m) {
       const groups = this.getNamedCaptureGroups(m);
-      this.func({ ...groups, ...query, url });
+      let func = this.funcOrObj;
+      if (typeof func !=='function') {
+        const key = fromOutside ? 'fromOutside' : 'fromInside';
+        func = func[key];
+      }
+      func({ ...groups, ...query, url });
       return true;
     }
     return false;

--- a/Misc.js
+++ b/Misc.js
@@ -1252,6 +1252,19 @@ SimpleHTMLView.propTypes = {
   lang: PropTypes.oneOf(['english', 'hebrew']),
 };
 
+const SimpleMarkdown = ({children, markdownProps}) => {
+  const {handleOpenURL} = useContext(ReaderAppContext);
+  const onLinkPress = (url) => {
+    handleOpenURL(url);
+    return false;
+  }
+  return <Markdown onLinkPress={onLinkPress} {...markdownProps}>{children}</Markdown>;
+}
+SimpleMarkdown.propTypes = {
+  children: PropTypes.string.isRequired,
+  markdownProps: PropTypes.object,
+}
+
 const SimpleContentBlock = ({en, he}) => {
   const { interfaceLanguage } = useContext(GlobalStateContext);
   const showHebrew = !!he;
@@ -1507,6 +1520,7 @@ const CategoryDescription = ({ description }) => {
           {...description}
           lang={menuLanguage}
           extraStyles={[{marginTop: 10, fontSize: 13}, theme.tertiaryText]}
+          RenderingComponent={SimpleMarkdown}
       />
   );
 };

--- a/Misc.js
+++ b/Misc.js
@@ -29,6 +29,8 @@ import { useHTMLViewStyles } from './useHTMLViewStyles';
 import { RenderHTML } from 'react-native-render-html';
 import BookSVG from './img/connection-book.svg';
 import ActionSheet from "react-native-action-sheet";
+import Markdown from "react-native-markdown-display";
+import ReaderAppContext from "./context";
 
 const SYSTEM_FONTS = ["Taamey Frank Taamim Fix", "Amiri", "Heebo", "OpenSans", "SertoBatnan"];  // list of system fonts. needed for RenderHTML
 const CSS_CLASS_STYLES = {
@@ -158,7 +160,7 @@ const InterfaceText = ({stringKey, lang, en, he, extraStyles = [], allowFontScal
   );
 };
 
-const InterfaceTextWithFallback = ({ en, he, extraStyles=[], lang }) => {
+const InterfaceTextWithFallback = ({ en, he, extraStyles=[], lang, RenderingComponent=Text }) => {
   const { interfaceLanguage } = useContext(GlobalStateContext);
   let langStyle = styles.enInt;
   let text = en;
@@ -168,7 +170,7 @@ const InterfaceTextWithFallback = ({ en, he, extraStyles=[], lang }) => {
     text = he;
   }
   return (
-    <Text style={[langStyle].concat(extraStyles)}>{text}</Text>
+    <RenderingComponent style={[langStyle].concat(extraStyles)}>{text}</RenderingComponent>
   );
 }
 
@@ -1634,4 +1636,5 @@ export {
   TwoBoxRow,
   singleActionPopup,
   openActionSheet,
+  SimpleMarkdown,
 }

--- a/ReaderApp.js
+++ b/ReaderApp.js
@@ -30,6 +30,7 @@ import SoundPlayer from 'react-native-sound-player'
 import { SearchState } from '@sefaria/search';
 
 import { STATE_ACTIONS } from './StateManager';
+import ReaderAppContext from './context';
 import ReaderControls from './ReaderControls';
 import styles from './Styles';
 import strings from './LocalizedStrings';
@@ -2310,61 +2311,64 @@ class ReaderApp extends React.PureComponent {
   render() {
     // StatuBar comment: can't figure out how to get barStyle = light-content to be respected on Android
     const { safeViewStyle, statusBarBackgroundColor, statusBarStyle } = getSafeViewStyleAndStatusBarBackground(this.state, this.props.theme.mainTextPanel, this.props.themeStr === "white");
-    return (
-      <View style={styles.rootContainer}>
-        <SafeAreaView edges={["top"]} style={[{ flex: 0 }, safeViewStyle]} />
-        <SafeAreaView
-           edges={this.getBottomSafeAreaEdges(this.state.menuOpen)}
-           style={[styles.safeArea, this.props.theme.mainTextPanel]}
-        >
-          <View style={[styles.container, this.props.theme.mainTextPanel]}>
-              <StatusBar barStyle={statusBarStyle} backgroundColor={statusBarBackgroundColor}/>
-            <ConditionalProgressWrapper
-              conditionMethod={(state, props) => {
-                return state && (props.menuOpen !== 'settings' || state.downloadNotification === 'Update');
-              }}
-              initialValue={DownloadTracker.getDownloadStatus()}
-              downloader={DownloadTracker}
-              listenerName={'ReaderAppBar'}
-              menuOpen={this.state.menuOpen}
-            >
-              <SefariaProgressBar
-                onPress={()=>{
-                  this.openMenu("settings")
-                }}
-                onClose={() => DownloadTracker.cancelDownload()}
-                download={DownloadTracker}
-                identity={'ReaderApp'}
-              />
-            </ConditionalProgressWrapper>
-              { this.renderContent() }
-            { this.shouldShowFooter(this.state.menuOpen) && (
-                <FooterTabBar selectedTabName={this.state.footerTab} setTab={this.setFooterTab} />
-            )}
-          </View>
-        </SafeAreaView>
-        <InterruptingMessage
-          ref={this._getInterruptingMessageRef}
-          interfaceLanguage={this.props.interfaceLanguage}
-          openInDefaultBrowser={this.openInDefaultBrowser}
-          debugInterruptingMessage={this.props.debugInterruptingMessage}
-        />
-        <DeepLinkRouter
-          ref={this._getDeepLinkRouterRef}
-          openNav={this.openNav}
-          openMenu={this.openMenu}
-          openRef={this.openRef}
-          openUri={this.openUri}
-          openRefSheet={this.openRefSheet}
-          openSearch={this.openSearch}
-          openTopic={this.openTopic}
-          setSearchOptions={this.setSearchOptions}
-          openTextTocDirectly={this.openTextTocDirectly}
-          setTextLanguage={this.setTextLanguage}
-          setNavigationCategories={this.setNavigationCategories}
-        />
-      </View>
+    const readerAppContextData = {handleOpenURL: this.handleOpenURL};
 
+    return (
+      <ReaderAppContext.Provider value={readerAppContextData}>
+        <View style={styles.rootContainer}>
+          <SafeAreaView edges={["top"]} style={[{ flex: 0 }, safeViewStyle]} />
+          <SafeAreaView
+             edges={this.getBottomSafeAreaEdges(this.state.menuOpen)}
+             style={[styles.safeArea, this.props.theme.mainTextPanel]}
+          >
+            <View style={[styles.container, this.props.theme.mainTextPanel]}>
+                <StatusBar barStyle={statusBarStyle} backgroundColor={statusBarBackgroundColor}/>
+              <ConditionalProgressWrapper
+                conditionMethod={(state, props) => {
+                  return state && (props.menuOpen !== 'settings' || state.downloadNotification === 'Update');
+                }}
+                initialValue={DownloadTracker.getDownloadStatus()}
+                downloader={DownloadTracker}
+                listenerName={'ReaderAppBar'}
+                menuOpen={this.state.menuOpen}
+              >
+                <SefariaProgressBar
+                  onPress={()=>{
+                    this.openMenu("settings")
+                  }}
+                  onClose={() => DownloadTracker.cancelDownload()}
+                  download={DownloadTracker}
+                  identity={'ReaderApp'}
+                />
+              </ConditionalProgressWrapper>
+                { this.renderContent() }
+              { this.shouldShowFooter(this.state.menuOpen) && (
+                  <FooterTabBar selectedTabName={this.state.footerTab} setTab={this.setFooterTab} />
+              )}
+            </View>
+          </SafeAreaView>
+          <InterruptingMessage
+            ref={this._getInterruptingMessageRef}
+            interfaceLanguage={this.props.interfaceLanguage}
+            openInDefaultBrowser={this.openInDefaultBrowser}
+            debugInterruptingMessage={this.props.debugInterruptingMessage}
+          />
+          <DeepLinkRouter
+            ref={this._getDeepLinkRouterRef}
+            openNav={this.openNav}
+            openMenu={this.openMenu}
+            openRef={this.openRef}
+            openUri={this.openUri}
+            openRefSheet={this.openRefSheet}
+            openSearch={this.openSearch}
+            openTopic={this.openTopic}
+            setSearchOptions={this.setSearchOptions}
+            openTextTocDirectly={this.openTextTocDirectly}
+            setTextLanguage={this.setTextLanguage}
+            setNavigationCategories={this.setNavigationCategories}
+          />
+        </View>
+      </ReaderAppContext.Provider>
     );
   }
 }

--- a/ReaderApp.js
+++ b/ReaderApp.js
@@ -388,12 +388,12 @@ class ReaderApp extends React.PureComponent {
     BackgroundFetch.finish(taskId);
   };
 
-  handleOpenURLNamedParam = ({ url } = {}) => {
+  handleOpenURLNamedParam = ({ url, fromOutside=true } = {}) => {
     // needs to be named param to be compatible with Linking API
     if (url) {
       url = url.replace(/^about:\/\/\//, Sefaria.api._baseHost);
       if (this.state._completedInit) {
-        this._deepLinkRouterRef.route(url);
+        this._deepLinkRouterRef.route(url, fromOutside);
       } else {
         // save URL. it will be applied when componentDidMount finishes
         this._initDeepLinkURL = url;
@@ -402,8 +402,9 @@ class ReaderApp extends React.PureComponent {
   };
 
   handleOpenURL = (url) => {
-    // unnamed parameter func used for HTMLView callback
-    this.handleOpenURLNamedParam({ url });
+    // unnamed parameter.
+    // func used for internal routing (e.g. HTMLView and Markdown)
+    this.handleOpenURLNamedParam({ url, fromOutside: false });
   };
 
   onDownloaderChange = (openSettings) => {

--- a/TopicList.js
+++ b/TopicList.js
@@ -16,6 +16,7 @@ import {
     InterfaceTextWithFallback,
     ContentTextWithFallback,
     SefariaPressable,
+    SimpleMarkdown,
 } from './Misc';
 
 const TopicList = ({ topics, openTopic, segmentRef, heSegmentRef }) => {
@@ -46,7 +47,7 @@ const TopicList = ({ topics, openTopic, segmentRef, heSegmentRef }) => {
 const TopicListItem = ({ topic, openTopic, segmentRef, heSegmentRef }) => {
   // TODO generalize DataSourceLine to handle ref text instead of topicTitle
   const {theme, menuLanguage} = useGlobalState();
-  const flexDirection = useRtlFlexDir(menuLanguage)       
+  const flexDirection = useRtlFlexDir(menuLanguage)
   return (
     <SefariaPressable
       onPress={() => { openTopic(new Topic({ slug: topic.topic, ...topic })); }}
@@ -57,7 +58,7 @@ const TopicListItem = ({ topic, openTopic, segmentRef, heSegmentRef }) => {
       </DataSourceLine>
       {
         topic.description && (topic.description.en || topic.description.he) ? (
-          <InterfaceTextWithFallback {...topic.description} extraStyles={[theme.tertiaryText, {marginTop: 10}]} lang={menuLanguage}/>
+          <InterfaceTextWithFallback {...topic.description} extraStyles={[theme.tertiaryText, {marginTop: 10}]} lang={menuLanguage} RenderingComponent={SimpleMarkdown}/>
         ) : null
       }
     </SefariaPressable>

--- a/TopicPage.js
+++ b/TopicPage.js
@@ -41,6 +41,7 @@ import Sefaria from './sefaria';
 import strings from './LocalizedStrings';
 import styles from './Styles';
 import {iconData} from "./IconData";
+import {SimpleMarkdown} from './Misc'
 
 const sortTopicCategories = (a, b, interfaceLanguage, isRoot) => {
   // Don't use display order intended for top level a category level. Bandaid for unclear semantics on displayOrder.
@@ -591,6 +592,7 @@ const TopicPageHeader = ({ title, slug, description, topicsTab, setTopicsTab, qu
         <InterfaceTextWithFallback
           extraStyles={[{fontSize: 13}, theme.tertiaryText]}
           {...description}
+          RenderingComponent={SimpleMarkdown}
         />
       ) : null }
       <PortalLink topicSlug={slug} portal={portal} openUri={openUri} />

--- a/context.js
+++ b/context.js
@@ -1,0 +1,5 @@
+import React  from 'react';
+
+const ReaderAppContext = React.createContext({});
+
+export default ReaderAppContext;

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "react-native-haptic-feedback": "^1.13.1",
         "react-native-inappbrowser-reborn": "^3.7.0",
         "react-native-localization": "^2.3.1",
+        "react-native-markdown-display": "^7.0.2",
         "react-native-play-install-referrer": "^1.1.8",
         "react-native-render-html": "^6.3.4",
         "react-native-root-toast": "^3.2.1",
@@ -16996,6 +16997,15 @@
         "node": "> 0.4.x < 0.9.0"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "node_modules/localized-strings": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/localized-strings/-/localized-strings-0.2.4.tgz",
@@ -17334,6 +17344,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "entities": "~2.0.0",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/marky": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
@@ -17372,6 +17404,12 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
       "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+    },
+    "node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "license": "MIT"
     },
     "node_modules/memoize-one": {
       "version": "5.2.1",
@@ -20598,6 +20636,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-native-fit-image": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/react-native-fit-image/-/react-native-fit-image-1.5.5.tgz",
+      "integrity": "sha512-Wl3Vq2DQzxgsWKuW4USfck9zS7YzhvLNPpkwUUCF90bL32e1a0zOVQ3WsJILJOwzmPdHfzZmWasiiAUNBkhNkg==",
+      "license": "Beerware",
+      "dependencies": {
+        "prop-types": "^15.5.10"
+      }
+    },
     "node_modules/react-native-gesture-handler": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.14.1.tgz",
@@ -20651,6 +20698,22 @@
         "react-native-windows": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-markdown-display": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-markdown-display/-/react-native-markdown-display-7.0.2.tgz",
+      "integrity": "sha512-Mn4wotMvMfLAwbX/huMLt202W5DsdpMO/kblk+6eUs55S57VVNni1gzZCh5qpznYLjIQELNh50VIozEfY6fvaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-to-react-native": "^3.0.0",
+        "markdown-it": "^10.0.0",
+        "prop-types": "^15.7.2",
+        "react-native-fit-image": "^1.5.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.2.0",
+        "react-native": ">=0.50.4"
       }
     },
     "node_modules/react-native-play-install-referrer": {
@@ -24646,6 +24709,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "license": "MIT"
     },
     "node_modules/uglify-es": {
       "version": "3.3.9",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react-native-haptic-feedback": "^1.13.1",
     "react-native-inappbrowser-reborn": "^3.7.0",
     "react-native-localization": "^2.3.1",
+    "react-native-markdown-display": "^7.0.2",
     "react-native-play-install-referrer": "^1.1.8",
     "react-native-render-html": "^6.3.4",
     "react-native-root-toast": "^3.2.1",


### PR DESCRIPTION
1. adds `react-native-markdown-display` library.
2. adds `context` to `ReaderApp` (for now only contains `handleOpenURL`).
3. new component `SimpleMarkdown` in `Misc.js`. This component renders markdown with `handleOpenURL` for links.
4. refactor `InterfaceTextWithFallback` for rendering text with other components than `Text`.
5. renders topic description (in 3 different places) with `SimpleMarkdown` and `InterfaceTextWithFallback`.
6. adds param `fromOutside` to `handleOpenURLNamedParam`, and passing it to `route`.
7. refactor `Route`'s param `func` to `funcOrObj`, and when it's obj, decides which function to call accoring to `fromOutside`.
8. routes inside topics links to the native app, while outside topic links still routes to web.