### PR TITLE
show only-online-translations when the text exists offline

### DIFF
--- a/offline.js
+++ b/offline.js
@@ -38,6 +38,7 @@ export const getAllTranslationsOffline = async function (ref, context=true) {
                 const result = await loadTextOffline(ref, context, {[version.language]: version.versionTitle}, false);
                 if (result.missingLangs?.includes(version.language)) {
                     missingVersions.push(version);
+                    continue;
                 }
                 const copiedVersion = {...version};
                 const desired_attr = (version.direction === 'rtl') ? 'he' : 'text';

--- a/offline.js
+++ b/offline.js
@@ -268,13 +268,7 @@ const loadOfflineSection = async function(ref, versions, fallbackOnDefaultVersio
 
     const [metadata, fileNameStem] = await loadOfflineSectionMetadataWithCache(ref);
     const textByLang = await loadOfflineSectionByVersions(versions, metadata.versions, metadata.sectionRef, fileNameStem, fallbackOnDefaultVersions);
-    const fullSectionObject = createFullSectionObject(metadata, textByLang);
-    for (const lang in versions) {
-        if (!textByLang[lang].length) {
-            (fullSectionObject.missingLangs ||= []).push(lang);
-        }
-    }
-    return fullSectionObject;
+    return createFullSectionObject(metadata, textByLang, Object.keys(versions));
 };
 
 const loadOfflineSectionByVersions = async function(selectedVersions, allVersions, ref, fileNameStem, fallbackOnDefaultVersions=true) {
@@ -308,7 +302,7 @@ const loadOfflineSectionByVersions = async function(selectedVersions, allVersion
     return textByLang;
 };
 
-const createFullSectionObject = (metadata, textByLang, cacheKey) => {
+const createFullSectionObject = (metadata, textByLang, requestedLangs, cacheKey) => {
     /**
      * Given metadata file and text for each version, combine them into a full section object which is used by the reader
      */
@@ -325,7 +319,14 @@ const createFullSectionObject = (metadata, textByLang, cacheKey) => {
         });
     }
 
+    requestedLangs.forEach(lang => {
+        if (!textByLang[lang].length) {
+            (fullSection.missingLangs ||= []).push(lang);
+        }
+    });
+
     Sefaria._jsonSectionData[cacheKey] = fullSection;
+
     return fullSection;
 };
 

--- a/offlineOnline.js
+++ b/offlineOnline.js
@@ -22,11 +22,10 @@ export const loadText = function(ref, context, versions, fallbackOnDefaultVersio
     if (typeof context === "undefined") { context = true; }
     return loadTextOffline(ref, context, versions, fallbackOnDefaultVersions)
         .then((result) => {
-            if (result && !result?.missingLangs?.length) {
-                return result;
-            } else if (result?.missingLangs?.length) {
+            if (result?.missingLangs?.length) {
                 throw ERRORS.MISSING_OFFLINE_DATA;
             }
+            return result;
         })
         .catch(error => {
             if (error === ERRORS.MISSING_OFFLINE_DATA) {

--- a/offlineOnline.js
+++ b/offlineOnline.js
@@ -20,22 +20,28 @@ export const loadText = function(ref, context, versions, fallbackOnDefaultVersio
      versions is object with keys { en, he } specifying version titles of requested ref
      */
     if (typeof context === "undefined") { context = true; }
-    return new Promise(function(resolve, reject) {
-        loadTextOffline(ref, context, versions, fallbackOnDefaultVersions).then(resolve)
-        .catch(error => {
-            if (error === ERRORS.MISSING_OFFLINE_DATA) {
-                api.textApi(ref, context, versions)
-                .then(data => {
-                    api.processTextApiData(ref, context, versions, data);
-                    resolve(data);
-                })
-                .catch(error => reject(error))
-            } else {
-                console.error("Error loading offline file", error);
-                reject(error);
+    return loadTextOffline(ref, context, versions, fallbackOnDefaultVersions)
+        .then((result) => {
+            if (result && !result?.missingLangs?.length) {
+                return result;
+            } else if (result?.missingLangs?.length) {
+                throw ERRORS.MISSING_OFFLINE_DATA;
             }
         })
-    });
+        .catch(error => {
+            if (error === ERRORS.MISSING_OFFLINE_DATA) {
+                return api.textApi(ref, context, versions)
+                    .then(data => {
+                        api.processTextApiData(ref, context, versions, data);
+                        return data;
+                    })
+            }
+            console.error("Error loading offline file", error);
+            return Promise.reject(error);
+        })
+        .catch((error) => {
+            return Promise.reject(error);
+        })
 };
 
 export const loadVersions = async (ref) => {
@@ -47,8 +53,9 @@ export const loadVersions = async (ref) => {
 };
 
 export const loadTranslations = async (ref) => {
-    let translations = await getAllTranslationsOffline(ref);
-    if (!translations) {
+    const offlineTranslations = await getAllTranslationsOffline(ref);
+    let translations = offlineTranslations?.translations || [];
+    if (!offlineTranslations || offlineTranslations.missingVersions.length) {
         translations = await api.translations(ref);
     }
     return translations;


### PR DESCRIPTION
when we have a text offline, in most of the texts we have only one 'en' version of it. so if we try to open another translation, the offline method will return the 'he' version with empty for the 'en'.

this commit fixes it:
1. when there is a request for a specific 'en' version offline, and it comes empty, the offline return object includes a key of missingLangs.
2. when offlineOnline methods gets this key, they try the api method. if it comes from the api it will be returned, and if not (no network) the offline partial result will be returned.
3. the offlineOnline methods are loadTranslations (for the translations box) and loadText (for showing text anywhere else).