### PR TITLE
feat(DeepLinkRouter): route sheets links to browser.

### DIFF
--- a/DeepLinkRouter.js
+++ b/DeepLinkRouter.js
@@ -27,12 +27,8 @@ class DeepLinkRouter extends React.PureComponent {
       ['^texts/(history)$', this.openMenu, ['menu']],
       ['^texts/(.+)?$', this.openCats, ['cats']],
       ['^search$', this.openSearch],
-      ['^(sheets)$', this.openMenu, ['menu']],
-      ['^(sheets)/tags$', this.openMenu, ['menu']],
-      ['^sheets/tags/(.+)$', this.openTopicFromTag, ['tag']],
       ['^topics/(category)/(.+)$', this.openTopic, ['categoryString','slug']],
       ['^topics/(.+)$', {fromOutside: this.catchAll, fromInside: this.openTopic}, ['slug']],
-      ['^sheets/([0-9.]+)$', this.openRefSheet, ['sheetid']],
       ['^([^/]+)$', this.openRef, ['tref']],  // NOTE: if any static page matches a title, it will try to be opened in the app. In this case, we'll need to explicitly list the route above this route.
       ['^.*$', this.catchAll],
     ];


### PR DESCRIPTION
Removing explicit rules for routing sheets to app, which cause them to be handled by catchAll and open in browser.