### PR TITLE
Fix(_toURL): Empty Version Objects Causing URL Construction Errors

### DIFF
--- a/ReaderApp.js
+++ b/ReaderApp.js
@@ -666,6 +666,10 @@ class ReaderApp extends React.PureComponent {
   loadNewText = ({ ref, versions, isLoadingVersion = false, numTries = 0 }) => {
     // Open ranged refs to their first segment (not ideal behavior, but good enough for now)
     ref = ref.indexOf("-") !== -1 ? ref.split("-")[0] : ref;
+    
+    // Sanitize versions to prevent url.replace errors
+    versions = Sefaria.api.sanitizeVersions(versions);
+
     return new Promise((resolve, reject) => {
       this.setState({
           loaded: false,
@@ -1134,6 +1138,9 @@ class ReaderApp extends React.PureComponent {
         ...versions,
       };
 
+      // Sanitize versions to prevent url.replace errors
+      const sanitizedVersions = Sefaria.api.sanitizeVersions(newVersions);
+
       // make sure loaded text will show the versions you selected
       let newTextLang = this.props.textLanguage;
       if (newTextLang !== 'bilingual' && loadNewVersions) {
@@ -1164,7 +1171,7 @@ class ReaderApp extends React.PureComponent {
         connectionsMode: null,
       }, () => {
           this.closeMenu(); // Don't close until these values are in state, so we know if we need to load defualt text
-          this.loadNewText({ ref, versions: newVersions }).then(resolve);
+          this.loadNewText({ ref, versions: sanitizedVersions }).then(resolve);
       });
     })
   };

--- a/ReaderApp.js
+++ b/ReaderApp.js
@@ -667,9 +667,6 @@ class ReaderApp extends React.PureComponent {
     // Open ranged refs to their first segment (not ideal behavior, but good enough for now)
     ref = ref.indexOf("-") !== -1 ? ref.split("-")[0] : ref;
     
-    // Sanitize versions to prevent url.replace errors
-    versions = Sefaria.api.sanitizeVersions(versions);
-
     return new Promise((resolve, reject) => {
       this.setState({
           loaded: false,
@@ -1138,9 +1135,6 @@ class ReaderApp extends React.PureComponent {
         ...versions,
       };
 
-      // Sanitize versions to prevent url.replace errors
-      const sanitizedVersions = Sefaria.api.sanitizeVersions(newVersions);
-
       // make sure loaded text will show the versions you selected
       let newTextLang = this.props.textLanguage;
       if (newTextLang !== 'bilingual' && loadNewVersions) {
@@ -1171,7 +1165,7 @@ class ReaderApp extends React.PureComponent {
         connectionsMode: null,
       }, () => {
           this.closeMenu(); // Don't close until these values are in state, so we know if we need to load defualt text
-          this.loadNewText({ ref, versions: sanitizedVersions }).then(resolve);
+          this.loadNewText({ ref, versions: newVersions }).then(resolve);
       });
     })
   };

--- a/ReaderApp.js
+++ b/ReaderApp.js
@@ -225,12 +225,6 @@ class ReaderApp extends React.PureComponent {
     this.linkingSubscription.remove();
     this.RNShakeSubscription.remove();
     DownloadTracker.unsubscribe('ReaderApp')
-    
-    // Clean up the text loaded timeout
-    if (this.checkTextLoadedTimeout) {
-      clearTimeout(this.checkTextLoadedTimeout);
-      this.checkTextLoadedTimeout = null;
-    }
   }
 
   promptLibraryDownload() {
@@ -687,21 +681,7 @@ class ReaderApp extends React.PureComponent {
           textToc: null,
       },
       () => {
-        // Set up a timeout to check if text loaded after 10 seconds
-        this.checkTextLoadedTimeout = setTimeout(() => {
-          if (!this.state.loaded) {
-            console.error(`Text failed to load after 10 seconds for ref: ${ref}. Throwing 'Return to Nav'`);
-            throw "Return to Nav";
-          }
-        }, 10000);
-
         Sefaria.offlineOnline.loadText(ref, true, versions, !this.state.hasInternet, true).then(data => { // Silencing the popup on failed Sefaria.api._requests and creating a new pop up if an error arises
-            // Clear the timeout since text loaded successfully
-            if (this.checkTextLoadedTimeout) {
-              clearTimeout(this.checkTextLoadedTimeout);
-              this.checkTextLoadedTimeout = null;
-            }
-            
             // debugger;
                 // if specific versions were requested, but no content exists for those versions, try again with default versions
             if (Sefaria.util.objectHasNonNullValues(data.nonExistantVersions) ||
@@ -757,12 +737,6 @@ class ReaderApp extends React.PureComponent {
 
             resolve();
         }).catch(error => {
-          // Clear the timeout in case of error
-          if (this.checkTextLoadedTimeout) {
-            clearTimeout(this.checkTextLoadedTimeout);
-            this.checkTextLoadedTimeout = null;
-          }
-          
           console.log(`Dealing with error: ${error}. Ref: ${ref}`);
           if (error == "Return to Nav") {
             // In case of unfound ref, try going one ref up (up to the book) before dealing with error by returning to nav.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,7 +1,7 @@
 def VERSION_BUILD=62060087
 def VERSION_MAJOR=6
 def VERSION_MINOR=4
-def VERSION_PATCH=29
+def VERSION_PATCH=26
 
 apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,7 +1,7 @@
 def VERSION_BUILD=62060087
 def VERSION_MAJOR=6
 def VERSION_MINOR=4
-def VERSION_PATCH=26
+def VERSION_PATCH=29
 
 apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"

--- a/api.js
+++ b/api.js
@@ -171,9 +171,6 @@ var Api = {
           url += 'api/texts/';
           urlSuffix = `?context=${context === true ? 1 : 0}&commentary=0`;
           if (versions) {
-            // BUGFIX Patch: Bookmarks created from topic can pass empty objects {en: {}, he: {}}
-            // instead of strings or nulls for version values, causing url.replace errors.
-            // We check that each version is actually a string before trying to sanitize it.
             if (typeof versions.en === 'string') {
               urlSuffix += `&ven=${this._sanitizeURL(versions.en)}`;
             }

--- a/api.js
+++ b/api.js
@@ -36,20 +36,6 @@ var Api = {
   _lexiconCache: {},
   _currentRequests: {}, // object to remember current request in order to abort. keyed by apiType
   
-  // Utility function to sanitize version objects
-  sanitizeVersions: function(versions) {
-    if (!versions) return versions;
-    
-    const sanitized = {...versions};
-    if (sanitized.en && typeof sanitized.en === 'object' && Object.keys(sanitized.en).length === 0) {
-      delete sanitized.en;
-    }
-    if (sanitized.he && typeof sanitized.he === 'object' && Object.keys(sanitized.he).length === 0) {
-      delete sanitized.he;
-    }
-    return sanitized;
-  },
-  
   _textCacheKey: function(ref, context, versions) {
     return `${ref}|${context}${(!!versions ? (!!versions.en ? `|en:${versions.en}` : "") + (!!versions.he ? `|he:${versions.he}` : "")  : "")}`;
   },
@@ -185,6 +171,9 @@ var Api = {
           url += 'api/texts/';
           urlSuffix = `?context=${context === true ? 1 : 0}&commentary=0`;
           if (versions) {
+            // BUGFIX: Bookmarks created from topic searches can pass empty objects {en: {}, he: {}}
+            // instead of strings or nulls for version values, causing url.replace errors.
+            // We check that each version is actually a string before trying to sanitize it.
             if (versions.en && typeof versions.en === 'string') {
               urlSuffix += `&ven=${this._sanitizeURL(versions.en)}`;
             }
@@ -293,9 +282,6 @@ var Api = {
     });
   },
   textApi: async function(ref, context, versions, failSilently=false) {
-    // Sanitize versions to prevent url.replace errors
-    versions = Sefaria.api.sanitizeVersions(versions);
-
     const cacheValue = Sefaria.api.textCache(ref, context, versions);
     if (cacheValue) {
       // Don't check the API cahce until we've checked for a local file, because the API

--- a/api.js
+++ b/api.js
@@ -168,9 +168,10 @@ var Api = {
       switch (apiType) {
         case "text":
           const { context, versions, stripItags } = extra_args;
-          url += 'api/texts/';
           urlSuffix = `?context=${context === true ? 1 : 0}&commentary=0`;
           if (versions) {
+            // Patch: We disregard the version if it's not a string to deal with the change of structure around the move to RTL
+            // TODO: Add an analytics event to track when a version is an object
             if (typeof versions.en === 'string') {
               urlSuffix += `&ven=${this._sanitizeURL(versions.en)}`;
             }

--- a/api.js
+++ b/api.js
@@ -174,7 +174,7 @@ var Api = {
             // BUGFIX Patch: Bookmarks created from topic can pass empty objects {en: {}, he: {}}
             // instead of strings or nulls for version values, causing url.replace errors.
             // We check that each version is actually a string before trying to sanitize it.
-            if (versions.en && typeof versions.en === 'string') {
+            if (typeof versions.en === 'string') {
               urlSuffix += `&ven=${this._sanitizeURL(versions.en)}`;
             }
             if (versions.he && typeof versions.he === 'string') {

--- a/api.js
+++ b/api.js
@@ -171,7 +171,7 @@ var Api = {
           url += 'api/texts/';
           urlSuffix = `?context=${context === true ? 1 : 0}&commentary=0`;
           if (versions) {
-            // BUGFIX: Bookmarks created from topic searches can pass empty objects {en: {}, he: {}}
+            // BUGFIX Patch: Bookmarks created from topic can pass empty objects {en: {}, he: {}}
             // instead of strings or nulls for version values, causing url.replace errors.
             // We check that each version is actually a string before trying to sanitize it.
             if (versions.en && typeof versions.en === 'string') {


### PR DESCRIPTION
## Issue
Bookmarks created from topic pages were causing an endless loading spinner, with the error:

    url.replace is not a function

When navigating from a topic page to a text and bookmarking it, the app was storing version info as empty objects (`{ en: {}, he: {} }`) instead of strings or `null`.

## Fix
Verify that each version value is actually a string before sanitizing it, so that we never call `.replace()` on an object.

## Implementation
In **`api.js`** (_toURL method), wrap the version-suffix logic in a `typeof` check:

    // Before sanitizing, ensure versions.en is a string
    if (versions.en && typeof versions.en === 'string') {
      urlSuffix += `&ven=${this._sanitizeURL(versions.en)}`;
    }

    // Similarly for Hebrew, if needed:
    if (versions.he && typeof versions.he === 'string') {
      urlSuffix += `&vhe=${this._sanitizeURL(versions.he)}`;
    }

## Next Steps
1. **Verify version data**  
   What should happen when those version-objects actually contain valid version strings?  
2. **E2E test**  
   Ensure bookmarking texts from topic pages now works and does not break existing flows.
   The bookmark that is saved can also not be deleted.
