### PR TITLE
V6.4.30

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,7 +1,7 @@
-def VERSION_BUILD=62060087
+def VERSION_BUILD=62060092
 def VERSION_MAJOR=6
 def VERSION_MINOR=4
-def VERSION_PATCH=26
+def VERSION_PATCH=30
 
 apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"

--- a/api.js
+++ b/api.js
@@ -168,6 +168,7 @@ var Api = {
       switch (apiType) {
         case "text":
           const { context, versions, stripItags } = extra_args;
+          url += 'api/texts/';
           urlSuffix = `?context=${context === true ? 1 : 0}&commentary=0`;
           if (versions) {
             // Patch: We disregard the version if it's not a string to deal with the change of structure around the move to RTL


### PR DESCRIPTION
fix(_toURL): Important fix returning a line of code that was mistakenly removed causing all Android text API calls to fail.
Also bumped up version and code number with android deploy.