### PR TITLE
rn-77-fix-toc-arrows

### DIFF
--- a/Misc.js
+++ b/Misc.js
@@ -725,11 +725,17 @@ const CollapseIcon = ({ showHebrew, isVisible }) => {
     }
   }
   return (
-    <Image
-      source={src}
-      style={[(showHebrew ? styles.collapseArrowHe : styles.collapseArrowEn), Platform.OS === 'android' ? {marginTop: 3} : null]}
-      resizeMode={'contain'}
-    />
+      // arrow margins vary greatly depending on the platform and language
+      <View style={[
+          (showHebrew ? styles.collapseArrowOuterHe : styles.collapseArrowOuterEn),
+          (Platform.OS === 'android' ? (showHebrew ? styles.collapseArrowAndroidHe : styles.collapseArrowAndroidEn) : (showHebrew ? styles.collapseArrowIOSHe : null))
+      ]}>
+        <Image
+            source={src}
+            style={styles.collapseArrow}
+            resizeMode={'contain'}
+        />
+      </View>
   );
 }
 CollapseIcon.propTypes = {

--- a/Misc.js
+++ b/Misc.js
@@ -725,10 +725,12 @@ const CollapseIcon = ({ showHebrew, isVisible }) => {
     }
   }
   return (
-      // arrow margins vary greatly depending on the platform and language
+      // React Native 0.77 caused differences in spacing for this arrow icon on iOS and Android and English and Hebrew
+      // We are accounting for this with fine-grained styling below
       <View style={[
           (showHebrew ? styles.collapseArrowOuterHe : styles.collapseArrowOuterEn),
-          (Platform.OS === 'android' ? (showHebrew ? styles.collapseArrowAndroidHe : styles.collapseArrowAndroidEn) : (showHebrew ? styles.collapseArrowIOSHe : null))
+          (Platform.OS === 'android' ? (showHebrew ? styles.collapseArrowAndroidHe : styles.collapseArrowAndroidEn) :
+              (showHebrew ? styles.collapseArrowIOSHe : null))
       ]}>
         <Image
             source={src}

--- a/Styles.js
+++ b/Styles.js
@@ -475,16 +475,24 @@ export default StyleSheet.create({
     height: 15,
     paddingRight: 25,
   },
-  collapseArrowEn: {
-    width: 12,
-    height: 12,
-    paddingLeft: 20,
+  collapseArrowOuterEn: {
+    marginLeft: 5,
   },
-  collapseArrowHe: {
+  collapseArrowOuterHe: {
+    marginRight: 5,
+  },
+  collapseArrowAndroidEn: {
+    marginTop: 6,
+  },
+  collapseArrowAndroidHe: {
+    marginTop: 3,
+  },
+  collapseArrowIOSHe: {
+    marginTop: 3,
+  },
+  collapseArrow: {
     width: 12,
     height: 12,
-    paddingRight: 20,
-    marginTop: 3
   },
   forwardButtonEn: {
     width: 12,


### PR DESCRIPTION

The arrows on complex text table of contents had incorrect spacing after upgrading to RN 77. This PR fixes that.