### PR TITLE
Update proptypes to deprecated lib

### DIFF
--- a/AboutBox.js
+++ b/AboutBox.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import {
   View,
   ScrollView,

--- a/AccountNavigationMenu.js
+++ b/AccountNavigationMenu.js
@@ -1,5 +1,5 @@
 'use strict';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import React, {useState, useEffect, useCallback, useContext} from 'react';
 import {
     ScrollView,

--- a/AuthPage.js
+++ b/AuthPage.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import React, { useState, useContext } from 'react';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import {
   View,
   ScrollView,

--- a/ConnectionsPanel.js
+++ b/ConnectionsPanel.js
@@ -1,5 +1,5 @@
 'use strict';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import React, {useState} from 'react';
 import {
   View,

--- a/ConnectionsPanelHeader.js
+++ b/ConnectionsPanelHeader.js
@@ -1,5 +1,5 @@
 'use strict';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import React, { Component } from 'react';
 import {
   View,

--- a/Dedication.js
+++ b/Dedication.js
@@ -1,5 +1,5 @@
 import React, {useContext} from 'react';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import {
   View,
   ScrollView,

--- a/DeepLinkRouter.js
+++ b/DeepLinkRouter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import URL from 'url-parse';
 import React from 'react';
 

--- a/LexiconBox.js
+++ b/LexiconBox.js
@@ -6,7 +6,7 @@ import {
   Text,
   ScrollView,
 } from 'react-native';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import {
   LoadingView,
   OrderedList,

--- a/Misc.js
+++ b/Misc.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 
 import React, { useContext, useState, useEffect, useReducer, useCallback } from 'react';
 import {

--- a/MySheetResult.js
+++ b/MySheetResult.js
@@ -1,5 +1,5 @@
 'use strict';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import React, { useContext } from 'react';
 import {
   Text,

--- a/ReaderApp.js
+++ b/ReaderApp.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import crashlytics from '@react-native-firebase/crashlytics';  // to setup up generic crashlytics reports
 
 import React from 'react';

--- a/ReaderControls.js
+++ b/ReaderControls.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import React, { useContext, useReducer } from 'react';
 import {
   Text,

--- a/ReaderDisplayOptionsMenu.js
+++ b/ReaderDisplayOptionsMenu.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 
 import React from 'react';
 import {

--- a/ReaderNavigationSheetList.js
+++ b/ReaderNavigationSheetList.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 
 import React from 'react';
 import {

--- a/ReaderTextTableOfContents.js
+++ b/ReaderTextTableOfContents.js
@@ -1,5 +1,5 @@
 'use strict';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import React, {useCallback, useState} from 'react';
 import {
   Text,

--- a/SettingsPage.js
+++ b/SettingsPage.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import React, { useContext, useState, useRef, useEffect } from 'react';
 import {
   StyleSheet,

--- a/SheetListInConnections.js
+++ b/SheetListInConnections.js
@@ -1,5 +1,5 @@
 'use strict';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import React, { useContext, useEffect, useState } from 'react';
 import {
   View,

--- a/SheetResult.js
+++ b/SheetResult.js
@@ -1,5 +1,5 @@
 'use strict';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import React, { useContext } from 'react';
 import {
   StyleSheet,

--- a/Story.js
+++ b/Story.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import React, { useContext }  from 'react';
-import PropTypes  from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import {
   View,
 } from 'react-native';

--- a/SwipeableCategoryList.js
+++ b/SwipeableCategoryList.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 
 import React, { useContext } from 'react';
 import {

--- a/TextColumn.js
+++ b/TextColumn.js
@@ -1,5 +1,5 @@
 'use strict';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import React, { useCallback } from 'react';
 import {
   View,

--- a/TextHeightMeasurer.js
+++ b/TextHeightMeasurer.js
@@ -2,7 +2,7 @@
 //also see related git discussion: https://github.com/facebook/react-native/issues/13727
 
 import React from 'react';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import { View, StyleSheet } from 'react-native';
 
 const measureBatchSize = 50;

--- a/TextList.js
+++ b/TextList.js
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import {
   View,
   FlatList,

--- a/TextRange.js
+++ b/TextRange.js
@@ -1,5 +1,5 @@
 'use strict';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import React, { useContext, useCallback } from 'react';
 import {
   View,

--- a/TextRangeContinuous.js
+++ b/TextRangeContinuous.js
@@ -1,5 +1,5 @@
 'use strict';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import React from 'react';
 import {
   View,

--- a/TextSegment.js
+++ b/TextSegment.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {

--- a/TopicList.js
+++ b/TopicList.js
@@ -1,5 +1,5 @@
 'use strict';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import React, { useContext, useEffect, useState } from 'react';
 import {
   View,

--- a/TopicPage.js
+++ b/TopicPage.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import React, { useState, useContext, useEffect, useCallback, useRef } from 'react';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import {
   View,
   Text,

--- a/TranslationsBox.js
+++ b/TranslationsBox.js
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useRef, useState } from 'react';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import {
   View,
   ScrollView,

--- a/VersionBlock.js
+++ b/VersionBlock.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import {
   View,
   Text,

--- a/WebViewPage.js
+++ b/WebViewPage.js
@@ -1,5 +1,5 @@
 'use strict';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import React, { useContext } from 'react';
 import {
   Text,

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "next-frame": "^0.2.3",
     "path": "^0.12.7",
     "performance-now": "^2.1.0",
-    "prop-types": "^15.7.2",
     "qs": "^6.11.2",
     "react": "18.3.1",
     "react-error-boundary": "^4.0.10",

--- a/search/AutocompleteList.js
+++ b/search/AutocompleteList.js
@@ -1,5 +1,5 @@
 'use strict';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import React from 'react';
 
 import {

--- a/search/AutocompletePage.js
+++ b/search/AutocompletePage.js
@@ -1,5 +1,5 @@
 'use strict';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import React from 'react';
 
 import {

--- a/search/SearchBar.js
+++ b/search/SearchBar.js
@@ -1,5 +1,5 @@
 'use strict';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import React, { useRef } from 'react';
 
 import {

--- a/search/SearchFilterPage.js
+++ b/search/SearchFilterPage.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import React from 'react';
 import {
     View,

--- a/search/SearchPage.js
+++ b/search/SearchPage.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 
 import React  from 'react';
 import { View } from 'react-native';

--- a/search/SearchResultList.js
+++ b/search/SearchResultList.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 
 import React from 'react';
 import {

--- a/search/SearchSheetResult.js
+++ b/search/SearchSheetResult.js
@@ -1,5 +1,5 @@
 'use strict';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'deprecated-react-native-prop-types';
 import React, { useContext } from 'react';
 import {
   StyleSheet,


### PR DESCRIPTION
Changed all the calls to the deprecated prop-types to now use, the aptly named, community supported, deprecated-react-native-prop-types.
Removed the old import from packages