### PR TITLE
fix(sso): clear cached Google account on login, not just register [sc-46734]

### DIFF
--- a/SSOButtons.js
+++ b/SSOButtons.js
@@ -53,16 +53,19 @@ const createGoogleSignInHandler = ({ authMode, setIsLoading, setLoadingProvider,
       // Pre-flight check succeeded -- this is the "clicked -> provider sheet
       // shown" gap the spec wants measured, so process_started fires here.
       onProcessStarted();
-      if (authMode === AUTH_MODE.REGISTER) {
-        // The native SDK remembers the last authorized account and would sign
-        // the user straight back in with it. On sign-up that's wrong: someone
-        // creating an account needs to choose which Google account it belongs
-        // to, not silently inherit whoever signed in last on this device.
-        // Best-effort — nothing to clear on a first run.
-        try {
-          await GoogleSignin.signOut();
-        } catch (e) {}
-      }
+      // The native SDK remembers the last authorized account and would sign
+      // the user straight back in with it, skipping the account chooser
+      // entirely. That's wrong on both paths: on sign-up someone creating an
+      // account needs to choose which Google account it belongs to rather
+      // than silently inherit whoever signed in last on this device, and on
+      // login it means a user with more than one Google account has no way
+      // to pick the other one -- they're stuck re-authorizing whichever
+      // account the SDK cached, however many times they tap the button.
+      // Clearing the cached account first is what forces the chooser to
+      // appear. Best-effort — nothing to clear on a first run.
+      try {
+        await GoogleSignin.signOut();
+      } catch (e) {}
       const response = await GoogleSignin.signIn();
       // Since v13 a cancellation RESOLVES as { type: 'cancelled', data: null }
       // rather than rejecting with SIGN_IN_CANCELLED, so it never reaches the

--- a/__tests__/ssoGoogleAccountChooser.test.js
+++ b/__tests__/ssoGoogleAccountChooser.test.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { TouchableOpacity } from 'react-native';
+import TestContextWrapper from '../TestContextWrapper';
+import { SSOButtons } from '../SSOButtons';
+import themeWhite from '../ThemeWhite';
+import { AUTH_MODE } from '../AuthConstants';
+
+// The native Google SDK caches the last authorized account and silently
+// re-signs the user in with it unless that cache is cleared first via
+// signOut() before signIn(). That clear used to be gated behind
+// `authMode === AUTH_MODE.REGISTER`, so on the LOGIN path the account
+// chooser never appeared: a user with two Google accounts on the device was
+// always re-authorized with whichever one was last used, with no way to pick
+// the other. These assert signOut() runs on both LOGIN and REGISTER so that
+// register-only gate can't be reintroduced.
+const SUCCESS = { type: 'success', data: { idToken: 'tok', user: {} } };
+
+let mockSignInResult;
+
+jest.mock('@react-native-google-signin/google-signin', () => ({
+  GoogleSignin: {
+    configure: jest.fn(),
+    hasPlayServices: jest.fn(() => Promise.resolve(true)),
+    signOut: jest.fn(() => Promise.resolve()),
+    signIn: jest.fn(() => Promise.resolve(mockSignInResult)),
+  },
+  statusCodes: { SIGN_IN_CANCELLED: 'SIGN_IN_CANCELLED' },
+}));
+
+const { GoogleSignin } = require('@react-native-google-signin/google-signin');
+
+const pressGoogle = async (authMode, handlers) => {
+  let instance;
+  await act(async () => {
+    instance = renderer.create(
+      <TestContextWrapper child={SSOButtons} childProps={{ authMode, theme: themeWhite, ...handlers }} />
+    );
+  });
+  const googleButton = instance.root.findAllByType(TouchableOpacity)[0];
+  await act(async () => { await googleButton.props.onPress(); });
+  await act(async () => { instance.unmount(); });
+};
+
+const makeHandlers = () => ({
+  onSSOSuccess: jest.fn(),
+  onSSOError: jest.fn(),
+  onMethodChosen: jest.fn(),
+  onProcessStarted: jest.fn(),
+  onProcessEnded: jest.fn(),
+});
+
+describe('Google sign-in cached-account clearing', () => {
+  beforeEach(() => {
+    mockSignInResult = SUCCESS;
+    GoogleSignin.signOut.mockClear();
+  });
+
+  test('clears the cached account on LOGIN so the chooser appears', async () => {
+    await pressGoogle(AUTH_MODE.LOGIN, makeHandlers());
+    expect(GoogleSignin.signOut).toHaveBeenCalledTimes(1);
+  });
+
+  test('still clears the cached account on REGISTER', async () => {
+    await pressGoogle(AUTH_MODE.REGISTER, makeHandlers());
+    expect(GoogleSignin.signOut).toHaveBeenCalledTimes(1);
+  });
+
+  test('signOut runs before signIn on the LOGIN path', async () => {
+    const callOrder = [];
+    GoogleSignin.signOut.mockImplementation(() => { callOrder.push('signOut'); return Promise.resolve(); });
+    GoogleSignin.signIn.mockImplementation(() => { callOrder.push('signIn'); return Promise.resolve(mockSignInResult); });
+    await pressGoogle(AUTH_MODE.LOGIN, makeHandlers());
+    expect(callOrder).toEqual(['signOut', 'signIn']);
+  });
+});


### PR DESCRIPTION
## Summary

Rachel reported that with two Google accounts on her device, she could never sign in with the second one -- the app always silently re-authorized her with whichever account was last used, and the Google account chooser never appeared on login.

**Root cause:** in `createGoogleSignInHandler` (`SSOButtons.js`), the `GoogleSignin.signOut()` call that clears the native SDK's cached account was gated behind `if (authMode === AUTH_MODE.REGISTER)`, so it never ran on the LOGIN path. The SDK remembers the last authorized account and silently signs the user back in with it unless that cache is cleared first.

**Fix:** the cached-account clear now runs unconditionally before `GoogleSignin.signIn()`, on both LOGIN and REGISTER, so the account chooser always appears. The existing best-effort try/catch is preserved (never throws). No other behavior in the handler changed -- the `type: 'cancelled'` early return, idToken handling, analytics calls, and error classification are untouched.

This is shared JS (`SSOButtons.js` has no platform branch for the Google button), so the fix applies to both iOS and Android.

## Test plan

- [x] Added `__tests__/ssoGoogleAccountChooser.test.js`, asserting `GoogleSignin.signOut()` is called on both the LOGIN and REGISTER paths (so the register-only gate can't be reintroduced), and that it runs before `signIn()`.
- [x] Ran all SSO/auth Jest suites on this branch -- all pass:

```
Test Suites: 7 passed, 7 total
Tests:       110 passed, 110 total
```//`ssoGoogleAccountChooser.test.js`, `ssoGoogleCancel.test.js`, `ssoAppleAndroid.test.js`, `ssoAppleCancel.test.js`, `ssoErrorCode.test.js`, `ssoLayout.test.js`, `AuthPage.test.js`